### PR TITLE
fixed typo with smt_rails was killing sprockets settings integration

### DIFF
--- a/lib/sht_rails/engine.rb
+++ b/lib/sht_rails/engine.rb
@@ -4,7 +4,7 @@ module ShtRails
       app.paths['app/views'] << ShtRails.template_base_path
     end
     
-    initializer "sprockets.smt_rails", :after => "sprockets.environment", :group => :all do |app|
+    initializer "sprockets.sht_rails", :after => "sprockets.environment", :group => :all do |app|
       next unless app.assets
       app.assets.register_engine(".#{ShtRails.template_extension}", Tilt)
       app.config.assets.paths << ShtRails.template_base_path


### PR DESCRIPTION
Hey great gem thanks, noticed an issue with a reference to smt_rails that was stopping the template path settings to be sent to sprockets etc.
