### PR TITLE
Server side helper support

### DIFF
--- a/lib/sht_rails/config.rb
+++ b/lib/sht_rails/config.rb
@@ -10,12 +10,12 @@ module ShtRails
   # end
 
   module Config
-    attr_accessor :template_base_path, :template_extension, :action_view_key, :template_namespace
+    attr_accessor :template_base_path, :template_extension, :action_view_key, :template_namespace, :helper_path
 
     def configure
       yield self
     end
-    
+
     def template_base_path
       @template_base_path ||= Rails.root.join("app", "templates")
     end
@@ -23,13 +23,17 @@ module ShtRails
     def template_extension
       @template_extension ||= 'handlebars'
     end
-    
+
     def action_view_key
       @action_view_key ||= 'handlebars'
     end
-    
+
     def template_namespace
       @template_namespace ||= 'SHT'
+    end
+
+    def helper_path
+      @helper_path ||= 'templates/helpers.js'
     end
   end
 end

--- a/lib/sht_rails/handlebars.rb
+++ b/lib/sht_rails/handlebars.rb
@@ -4,13 +4,26 @@ require "active_support"
 module ShtRails
 
   module Handlebars
+    def self.context(partials = nil)
+      @context = nil unless ActionView::Resolver.caching?
+      @context ||= begin
+        context = ::Handlebars::Context.new
+        if helpers = Rails.application.assets.find_asset(ShtRails.helper_path)
+          context.runtime.eval helpers.source
+        end
+        partials.each { |key, value| context.register_partial(key, value) } if partials
+        context
+      end
+    end
+
     def self.call(template)
       if template.locals.include?(ShtRails.action_view_key.to_s) || template.locals.include?(ShtRails.action_view_key.to_sym)
 <<-SHT
-  hbs_context_for_sht = Handlebars::Context.new
-  partials.each do |key, value|
-    hbs_context_for_sht.register_partial(key, value)
-  end if defined?(partials) && partials.is_a?(Hash)
+  hbs_context_for_sht = if defined?(partials) && partials.is_a?(Hash)
+    ShtRails::Handlebars.context(partials)
+  else
+    ShtRails::Handlebars.context
+  end
   hbs_context_for_sht.compile(#{template.source.inspect}).call(#{ShtRails.action_view_key.to_s} || {}).html_safe
 SHT
       else

--- a/sht_rails.gemspec
+++ b/sht_rails.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "rails",           ">= 3.1.0"
   gem.add_runtime_dependency "tilt",            ">= 1.3.3"
   gem.add_runtime_dependency "sprockets",       ">= 2.0.3"
-  gem.add_runtime_dependency "handlebars",      ">= 0.3.0"
+  gem.add_runtime_dependency "handlebars",      ">= 0.4.0"
   gem.add_runtime_dependency "execjs",          ">= 0.3.0"
 
   gem.add_development_dependency "rake"


### PR DESCRIPTION
Support running javascript helpers on the server by running them through the asset pipeline, then evaling them in the handlebars context. Fixes #3.

This expects helpers to be at app/assets/javascripts/templates/helpers.js, but that's configurable. It uses the asset pipeline, so compile to JS languages (Coffeescript) will work fine.

Depending on your setup, templates/helpers.js may need to be added to config.assets.precompile in production.rb.

This change also caches the handlebars context between requests in environments where view caching is enabled (production). I didn't actually benchmark (shame on me), but it seems like it ought to provide some sort of performance boost.
