### PR TITLE
added js dependency support for rails

### DIFF
--- a/lib/sht_rails/asset_dependency.rb
+++ b/lib/sht_rails/asset_dependency.rb
@@ -1,0 +1,13 @@
+module ShtRails
+  class AssetDependency
+    def initialize(path)
+      @path = path
+    end
+
+    def source
+      asset = Rails.application.assets.find_asset(@path)
+
+      asset.source unless asset.nil?
+    end
+  end
+end

--- a/lib/sht_rails/config.rb
+++ b/lib/sht_rails/config.rb
@@ -1,3 +1,6 @@
+require 'sht_rails/asset_dependency'
+require 'sht_rails/content_dependency'
+
 module ShtRails
   # Change config options in an initializer:
   #
@@ -12,7 +15,7 @@ module ShtRails
   module Config
     extend self
 
-    attr_writer :template_base_path, :template_extension, :action_view_key, :template_namespace, :helper_path
+    attr_writer :template_base_path, :template_extension, :action_view_key, :template_namespace, :helper_path, :dependencies
 
     def configure
       yield self
@@ -36,6 +39,10 @@ module ShtRails
 
     def helper_path
       @helper_path ||= 'templates/helpers.js'
+    end
+
+    def dependencies
+      @dependencies ||= []
     end
   end
 end

--- a/lib/sht_rails/content_dependency.rb
+++ b/lib/sht_rails/content_dependency.rb
@@ -1,0 +1,11 @@
+module ShtRails
+  class ContentDependency
+    def initialize(content)
+      @content = content
+    end
+
+    def source
+      @content
+    end
+  end
+end

--- a/lib/sht_rails/handlebars.rb
+++ b/lib/sht_rails/handlebars.rb
@@ -8,8 +8,12 @@ module ShtRails
       @context = nil unless ActionView::Resolver.caching?
       @context ||= begin
         context = ::Handlebars::Context.new
+        runtime = context.instance_variable_get(:@js)
+
+        ShtRails.dependencies.each { |dependency| runtime.eval dependency.source }
+
         if helpers = Rails.application.assets.find_asset(ShtRails.helper_path)
-          context.instance_variable_get(:@js).eval helpers.source
+          runtime.eval helpers.source
         end
         partials.each { |key, value| context.register_partial(key, value) } if partials
         context


### PR DESCRIPTION
I added this for the case when you want to use some functions in your helpers that are defined in other js files.
It can be used like so:

```
ShtRails.configure do |config|
  # ...
  config.dependencies = [
      ShtRails::ContentDependency.new('alert("here");'); # inline javascript content
      ShtRails::AssetDependency.new('I18n'), # gem asset
      ShtRails::AssetDependency.new('vendor/underscore') # app/assets/javascripts/vendor/underscore.js
  ]
end
```
