### PR TITLE
removes ActionView caching

### DIFF
--- a/lib/sht_rails/handlebars.rb
+++ b/lib/sht_rails/handlebars.rb
@@ -5,8 +5,7 @@ module ShtRails
 
   module Handlebars
     def self.context(partials = nil)
-      @context = nil unless ActionView::Resolver.caching?
-      @context ||= begin
+      @context = begin
         context = ::Handlebars::Context.new
         runtime = context.instance_variable_get(:@js)
 


### PR DESCRIPTION
1. Issue scenario:
2. View A contains partials 1 and 2
3. View B contains partials 2 and 3
4. App starts and in a caching env
5. User accesses view A
6. User accesses view B -> unknown partial 3 because the context has been memoized with partials 1 and 2
7. method has been removed in rails v3.1.0 http://apidock.com/rails/ActionView/Resolver/caching%3F
